### PR TITLE
AWG: Fix call to setExternalPotential()

### DIFF
--- a/api/mm/mmapi.F90
+++ b/api/mm/mmapi.F90
@@ -198,7 +198,8 @@ contains
     !> Gradient of the potential  on each atom. Shape: (3, nAtom)
     real(dp), intent(in), optional :: potGrad(:,:)
 
-    call setExternalPotential(atomPot, shellPot, potGrad)
+!AWG    call setExternalPotential(atomPot, shellPot, potGrad)
+    call setExternalPotential(atomPot=atomPot, potGrad=potGrad)
 
   end subroutine TDftbPlus_setExternalPotential
 

--- a/api/mm/mmapi.F90
+++ b/api/mm/mmapi.F90
@@ -187,7 +187,7 @@ contains
 
 
   !> Sets an external potential.
-  subroutine TDftbPlus_setExternalPotential(this, atomPot, potGrad)
+  subroutine TDftbPlus_setExternalPotential(this, atomPot, shellPot, potGrad)
 
     !> Instance.
     class(TDftbPlus), intent(inout) :: this
@@ -195,11 +195,13 @@ contains
     !> Potential acting on each atom. Shape: (nAtom)
     real(dp), intent(in), optional :: atomPot(:)
 
+    !> Shell resolved electrostatic potential. Shape: (orb%mShell,nAtom)
+    real(dp), intent(in), optional :: shellPot(:,:)
+
     !> Gradient of the potential  on each atom. Shape: (3, nAtom)
     real(dp), intent(in), optional :: potGrad(:,:)
 
-!AWG    call setExternalPotential(atomPot, shellPot, potGrad)
-    call setExternalPotential(atomPot=atomPot, potGrad=potGrad)
+    call setExternalPotential(atomPot, shellPot, potGrad)
 
   end subroutine TDftbPlus_setExternalPotential
 


### PR DESCRIPTION
shellPot(:) is missing, code does not compile.

Balint, please have a look. I commented the original call with !AWG

The code works now and Amber tests pass.