### PR TITLE
Return error code on Poisson solver init

### DIFF
--- a/external/poisson/poisson.F90
+++ b/external/poisson/poisson.F90
@@ -197,8 +197,9 @@ module poisson
          write(stdOut,*) 'ERROR: device and contact atoms overlap at contact',m
          if (present(iErr)) then
            iErr = -1
+         else
+           stop
          end if
-         exit
        end if  
      else                          
        xmin = minval(x(f,iatm(1):iatm(2)))
@@ -209,8 +210,9 @@ module poisson
          write(stdOut,*) 'ERROR: device and contact atoms overlap at contact',m
          if (present(iErr)) then
            iErr = -1
+         else
+           stop
          end if
-         exit
        end if  
      end if
   end do
@@ -232,8 +234,9 @@ module poisson
            write(stdOut,*) 'ERROR: contacts in the same direction must be aligned'
            if (present(iErr)) then
              iErr = -2
+           else
+             stop
            end if
-           STOP    
         endif
      enddo
      ! Adjust PoissonBox if there are no facing contacts
@@ -299,8 +302,9 @@ module poisson
         write(stdOut,*) "----------------------------------------------------"
         if (present(iErr)) then
           iErr = -3
+        else
+          stop
         end if
-        stop
      end if
   enddo
 
@@ -314,6 +318,11 @@ module poisson
         write(stdOut,*) "----------------------------------------------------"
         write(stdOut,*) "WARNING: Gate Distance too large!                   "
         write(stdOut,*) "----------------------------------------------------"
+        if (present(iErr)) then
+          iErr = -4
+        else
+          stop
+        end if
      end if
   endif
   
@@ -325,20 +334,28 @@ module poisson
         write(stdOut,*) "------------------------------------------"
         write(stdOut,*) "Gate insulator is longer than Poisson box!"
         write(stdOut,*) "------------------------------------------"
+        if (present(iErr)) then
+          iErr = -5
+        else
+          stop
+        end if
      end if
      
      do i = 1,3
         if (i.eq.biasdir) then
-           cycle
+          cycle
         end if
         if (((PoissBox(i,i))/2.d0).le.Rmin_Gate) then
            write(stdOut,*) "----------------------------------------------------"
            write(stdOut,*) "Gate transversal section is bigger than Poisson box!"
            write(stdOut,*) "----------------------------------------------------"
-           exit
+           if (present(iErr)) then
+             iErr = -6
+           else
+             stop
+           end if
         end if
      end do
-     
   end if
 
   !---------------------------------------

--- a/external/poisson/poisson.F90
+++ b/external/poisson/poisson.F90
@@ -143,12 +143,19 @@ module poisson
  end subroutine poiss_setparameters
 
  ! -----------------------------------------------------------------------------
- subroutine init_poissbox
+ subroutine init_poissbox(iErr)
+
+  !> Error code, 0 if no problems
+  integer, intent(out), optional :: iErr
 
   integer :: i,m,s,f
   real(kind=dp) :: bound(MAXNCONT) 
   real(kind=dp) :: tmp,Lx, xmax, xmin 
   integer :: tmpdir(3)
+
+  if (present(iErr)) then
+    iErr = 0
+  end if
 
   !*******************************************************************************
   ! 1. Set Poisson Box 
@@ -188,6 +195,9 @@ module poisson
          bound(m) = 0.5_dp * (xmax + xmin) + bufferBox
        else
          write(stdOut,*) 'ERROR: device and contact atoms overlap at contact',m
+         if (present(iErr)) then
+           iErr = -1
+         end if
          exit
        end if  
      else                          
@@ -197,6 +207,9 @@ module poisson
          bound(m) = 0.5_dp * (xmax + xmin) - bufferBox
        else
          write(stdOut,*) 'ERROR: device and contact atoms overlap at contact',m
+         if (present(iErr)) then
+           iErr = -1
+         end if
          exit
        end if  
      end if
@@ -217,6 +230,9 @@ module poisson
         endif
         if (contdir(m).eq.contdir(s).and.bound(s).ne.bound(m)) then
            write(stdOut,*) 'ERROR: contacts in the same direction must be aligned'
+           if (present(iErr)) then
+             iErr = -2
+           end if
            STOP    
         endif
      enddo
@@ -281,6 +297,9 @@ module poisson
         write(stdOut,*) "----------------------------------------------------"
         write(stdOut,*) "ERROR: PoissBox negative !                          "
         write(stdOut,*) "----------------------------------------------------"
+        if (present(iErr)) then
+          iErr = -3
+        end if
         stop
      end if
   enddo

--- a/prog/dftb+/lib_extlibs/poisson_int.F90
+++ b/prog/dftb+/lib_extlibs/poisson_int.F90
@@ -342,7 +342,7 @@ contains
       eps_r = poissoninfo%eps_r
       dr_eps = poissoninfo%dr_eps
 
-      ! Use fixed analytical renormalization (approximate) or numerical 
+      ! Use fixed analytical renormalization (approximate) or numerical
       fixed_renorm = .not.(poissoninfo%numericNorm)
 
       ! Performs parameters checks
@@ -418,7 +418,10 @@ contains
           write(stdOut,*) '                       SOLVING POISSON EQUATION         '
           write(stdOut,'(80("="))')
         end if
-        call init_PoissBox
+        call init_PoissBox(iErr)
+        if (iErr /= 0) then
+          call error("Failure during initialisation of the Poisson box")
+        end if
         call mudpack_drv(PoissFlag,V_L_atm,fakegrad)
       case(1)
         call mudpack_drv(PoissFlag,V_L_atm,grad_V)


### PR DESCRIPTION
Returns an error code from the Poisson box init under cases where either an error is printed or a return triggered.