### PR TITLE
 corrected sign in vdW component of gradients 

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -39,5 +39,7 @@ contributed to DFTB+ :
 
 * Michael Sternberg (Argonne National Laboratory, USA)
 
+* Martin Stöhr (University of Luxembourg, Luxembourg)
+
 * Frank Stuckenberg (University of Bremen, Germany)
 

--- a/prog/dftb+/prg_dftb/main.F90
+++ b/prog/dftb+/prg_dftb/main.F90
@@ -4102,7 +4102,7 @@ contains
   #:if WITH_MBD
     if (allocated(mbDispersion)) then
       call MBDgetGradients(mbDispersion, tmpDerivs)
-      derivs(:,:) = derivs + tmpDerivs
+      derivs(:,:) = derivs - tmpDerivs  !sign flip: vdW modules return forces not gradients
     end if
   #:endif
 


### PR DESCRIPTION
should restore energy-force-consistency