### PR TITLE
Eliminate globals - small changes

### DIFF
--- a/prog/dftb+/lib_dftb/dispuffdata.F90
+++ b/prog/dftb+/lib_dftb/dispuffdata.F90
@@ -35,7 +35,7 @@ module dftbp_dispuffdata
   !>
   !> (Data is awfully compressed, as F95 only allows 32 continuation lines and 132 characters per
   !> one line!)
-  type(TUFF) :: database(103) = (/&
+  type(TUFF), parameter :: database(103) = (/&
 TUFF("h ", 2.886_dp, 0.044_dp), TUFF("he", 2.362_dp, 0.056_dp), TUFF("li", 2.451_dp, 0.025_dp), TUFF("be", 2.745_dp, 0.085_dp), &
 TUFF("b ", 4.083_dp, 0.180_dp), TUFF("c ", 3.851_dp, 0.105_dp), TUFF("n ", 3.660_dp, 0.069_dp), TUFF("o ", 3.500_dp, 0.060_dp), &
 TUFF("f ", 3.364_dp, 0.050_dp), TUFF("ne", 3.243_dp, 0.042_dp), TUFF("na", 2.983_dp, 0.030_dp), TUFF("mg", 3.021_dp, 0.111_dp), &

--- a/prog/dftb+/lib_dftb/sccinit.F90
+++ b/prog/dftb+/lib_dftb/sccinit.F90
@@ -21,9 +21,6 @@ module dftbp_sccinit
   public :: initQFromAtomChrg, initQFromShellChrg, initQFromFile, writeQToFile
   public :: initQFromUsrChrg
 
-  !> Used to return runtime diagnostics
-  character(len=120) :: error_string
-
   !> version number for restart format, please increment if you change the interface.
   integer, parameter :: restartFormat = 4
 
@@ -233,6 +230,8 @@ contains
     !> requested to be re-loaded
     logical :: tBlock, tiBlock, tRho
 
+    character(len=120) :: error_string
+
     nAtom = size(qq, dim=2)
     nSpin = size(qq, dim=3)
 
@@ -438,6 +437,8 @@ contains
 
     !> Full density matrix with on-diagonal adjustment
     real(dp), intent(in), allocatable :: deltaRhoIn(:)
+
+    character(len=120) :: error_string
 
     integer :: nAtom, nOrb, nSpin
     integer :: iAtom, iOrb, iSpin, ii

--- a/prog/dftb+/lib_dftb/shortgamma.F90
+++ b/prog/dftb+/lib_dftb/shortgamma.F90
@@ -17,10 +17,6 @@ module dftbp_shortgamma
   public :: expGamma, expGammaDamped, expGammaPrime, expGammaDampedPrime
   public :: expGammaCutoff
 
-
-  !> Used to return runtime diagnostics
-  character(len=100) :: error_string
-
 contains
 
 
@@ -43,6 +39,7 @@ contains
     real(dp) :: cutValue
     real(dp) :: rab, MaxGamma, MinGamma, lowerGamma, gamma
     real(dp) :: cut, MaxCutOff, MinCutOff
+    character(len=100) :: error_string
 
     expGammaCutoff = 0.0_dp
 
@@ -113,6 +110,7 @@ contains
     real(dp) :: expGamma
 
     real(dp) :: tauA, tauB, tauMean
+    character(len=100) :: error_string
 
     if (rab < 0.0_dp) then
 99030 format ('Failure in short-range gamma, r_ab negative :',f12.6)
@@ -174,6 +172,7 @@ contains
     real(dp) :: expGammaPrime
 
     real(dp) :: tauA, tauB, tauMean
+    character(len=100) :: error_string
 
     if (rab < 0.0_dp) then
 99060 format ('Failure in short-range gamma, r_ab negative :',f12.6)
@@ -288,6 +287,8 @@ contains
     !> contribution
     real(dp) :: OhnoKlopman
 
+    character(len=100) :: error_string
+
     if (Ua < MinHubTol) then
 99090 format ('Failure in short-range gamma, U too small : ',f12.6)
       write(error_string, 99090) Ua
@@ -318,6 +319,8 @@ contains
 
     !> contribution
     real(dp) :: OhnoKlopmanPrime
+
+    character(len=100) :: error_string
 
     if (Ua < MinHubTol) then
 99110 format ('Failure in short-range gamma, U too small : ',f12.6)
@@ -351,6 +354,8 @@ contains
     !> contribution
     real(dp) :: gammaSubExprn
 
+    character(len=100) :: error_string
+
     if (abs(tau1 - tau2) < 3.2_dp*MinHubDiff) then
 99130 format ('Failure in gammaSubExprn, both tau degenerate ',f12.6,f12.6)
       write(error_string, 99130) tau1,tau2
@@ -383,6 +388,8 @@ contains
 
     !> contribution
     real(dp) :: gammaSubExprnPrime
+
+    character(len=100) :: error_string
 
     if (abs(tau1 - tau2) < 3.2_dp*MinHubDiff) then
 99150 format ('Failure in gammaSubExprn, both tau degenerate ',f12.6,f12.6)

--- a/prog/dftb+/lib_math/eigensolver.F90
+++ b/prog/dftb+/lib_math/eigensolver.F90
@@ -29,10 +29,6 @@ module dftbp_eigensolver
 #:endif
 
 
-  !> Used to return runtime diagnostics
-  character(len=100) :: error_string
-
-
   !> Simple eigensolver for a symmetric/Hermitian matrix
   !> Caveat: the matrix a is overwritten
   interface heev
@@ -126,6 +122,8 @@ contains
     integer n, info
     integer :: int_idealwork
     real(rsp) :: idealwork(1)
+    character(len=100) :: error_string
+
     @:ASSERT(uplo == 'u' .or. uplo == 'U' .or. uplo == 'l' .or. uplo == 'L')
     @:ASSERT(jobz == 'n' .or. jobz == 'N' .or. jobz == 'v' .or. jobz == 'V')
     @:ASSERT(all(shape(a)==size(w,dim=1)))
@@ -175,6 +173,8 @@ contains
     integer n, info
     integer :: int_idealwork
     real(rdp) :: idealwork(1)
+    character(len=100) :: error_string
+
     @:ASSERT(uplo == 'u' .or. uplo == 'U' .or. uplo == 'l' .or. uplo == 'L')
     @:ASSERT(jobz == 'n' .or. jobz == 'N' .or. jobz == 'v' .or. jobz == 'V')
     @:ASSERT(all(shape(a)==size(w,dim=1)))
@@ -225,6 +225,8 @@ contains
     integer n, info
     integer :: int_idealwork
     complex(rsp) :: idealwork(1)
+    character(len=100) :: error_string
+
     @:ASSERT(uplo == 'u' .or. uplo == 'U' .or. uplo == 'l' .or. uplo == 'L')
     @:ASSERT(jobz == 'n' .or. jobz == 'N' .or. jobz == 'v' .or. jobz == 'V')
     @:ASSERT(all(shape(a)==size(w,dim=1)))
@@ -276,6 +278,8 @@ contains
     integer n, info
     integer :: int_idealwork
     complex(rdp) :: idealwork(1)
+    character(len=100) :: error_string
+
     @:ASSERT(uplo == 'u' .or. uplo == 'U' .or. uplo == 'l' .or. uplo == 'L')
     @:ASSERT(jobz == 'n' .or. jobz == 'N' .or. jobz == 'v' .or. jobz == 'V')
     @:ASSERT(all(shape(a)==size(w,dim=1)))
@@ -334,6 +338,8 @@ contains
     integer n, lda, info, iitype, ldb
     integer :: int_idealwork
     real(r${VTYPE}$p) :: idealwork(1)
+    character(len=100) :: error_string
+
   @:ASSERT(uplo == 'u' .or. uplo == 'U' .or. uplo == 'l' .or. uplo == 'L')
   @:ASSERT(jobz == 'n' .or. jobz == 'N' .or. jobz == 'v' .or. jobz == 'V')
     n = size(a,dim=2)
@@ -402,6 +408,7 @@ contains
     real(rsp), allocatable :: rwork(:)
     integer n, info, iitype, int_idealwork
     complex(rsp) :: idealwork(1)
+    character(len=100) :: error_string
 
     @:ASSERT(uplo == 'u' .or. uplo == 'U' .or. uplo == 'l' .or. uplo == 'L')
     @:ASSERT(jobz == 'n' .or. jobz == 'N' .or. jobz == 'v' .or. jobz == 'V')
@@ -473,6 +480,7 @@ contains
     real(rdp), allocatable :: rwork(:)
     integer n, info, iitype, int_idealwork
     complex(rdp) :: idealwork(1)
+    character(len=100) :: error_string
 
     @:ASSERT(uplo == 'u' .or. uplo == 'U' .or. uplo == 'l' .or. uplo == 'L')
     @:ASSERT(jobz == 'n' .or. jobz == 'N' .or. jobz == 'v' .or. jobz == 'V')
@@ -545,6 +553,8 @@ contains
     integer :: int_idealwork, iidealwork(1)
     integer, allocatable :: iwork(:)
     real(rsp) :: idealwork(1)
+    character(len=100) :: error_string
+
     @:ASSERT(uplo == 'u' .or. uplo == 'U' .or. uplo == 'l' .or. uplo == 'L')
     @:ASSERT(jobz == 'n' .or. jobz == 'N' .or. jobz == 'v' .or. jobz == 'V')
     @:ASSERT(all(shape(a)==shape(b)))
@@ -617,6 +627,8 @@ contains
     integer :: int_idealwork, iidealwork(1)
     integer, allocatable :: iwork(:)
     real(rdp) :: idealwork(1)
+    character(len=100) :: error_string
+
     @:ASSERT(uplo == 'u' .or. uplo == 'U' .or. uplo == 'l' .or. uplo == 'L')
     @:ASSERT(jobz == 'n' .or. jobz == 'N' .or. jobz == 'v' .or. jobz == 'V')
     @:ASSERT(all(shape(a)==shape(b)))
@@ -691,6 +703,8 @@ contains
     integer, allocatable :: iwork(:)
     complex(rsp) :: idealwork(1)
     real(rsp) :: ridealwork(1)
+    character(len=100) :: error_string
+
     @:ASSERT(uplo == 'u' .or. uplo == 'U' .or. uplo == 'l' .or. uplo == 'L')
     @:ASSERT(jobz == 'n' .or. jobz == 'N' .or. jobz == 'v' .or. jobz == 'V')
     @:ASSERT(all(shape(a)==shape(b)))
@@ -767,6 +781,8 @@ contains
     integer, allocatable :: iwork(:)
     complex(rdp) :: idealwork(1)
     real(rdp) :: ridealwork(1)
+    character(len=100) :: error_string
+
     @:ASSERT(uplo == 'u' .or. uplo == 'U' .or. uplo == 'l' .or. uplo == 'L')
     @:ASSERT(jobz == 'n' .or. jobz == 'N' .or. jobz == 'v' .or. jobz == 'V')
     @:ASSERT(all(shape(a)==shape(b)))
@@ -865,6 +881,7 @@ contains
     logical :: subspace
     integer :: ii, jj
     character :: uplo_new
+    character(len=100) :: error_string
 
     n = size(a, dim=1)
 
@@ -1079,6 +1096,7 @@ contains
     logical :: subspace
     integer :: ii, jj
     character :: uplo_new
+    character(len=100) :: error_string
 
     n = size(a, dim=1)
 
@@ -1296,6 +1314,7 @@ contains
     logical :: subspace
     integer :: ii, jj
     character :: uplo_new
+    character(len=100) :: error_string
 
     n = size(a, dim=1)
     @:ASSERT(uplo == 'u' .or. uplo == 'U' .or. uplo == 'l' .or. uplo == 'L')
@@ -1516,6 +1535,7 @@ contains
     logical :: subspace
     integer :: ii, jj
     character :: uplo_new
+    character(len=100) :: error_string
 
     n = size(a, dim=1)
 
@@ -1703,6 +1723,7 @@ contains
     integer :: n, ka, kb, ldab, ldbb, ldz, info
     character :: jobz
     real(rsp) :: zTmp(1,1)
+    character(len=100) :: error_string
 
     if (present(z)) then
       jobz = 'v'
@@ -1781,6 +1802,7 @@ contains
     integer :: n, ka, kb, ldab, ldbb, ldz, info
     character :: jobz
     real(rdp) :: zTmp(1,1)
+    character(len=100) :: error_string
 
     if (present(z)) then
       jobz = 'v'
@@ -1860,6 +1882,7 @@ contains
     integer :: n, ka, kb, ldab, ldbb, ldz, info
     character :: jobz
     complex(rsp) :: zTmp(1,1)
+    character(len=100) :: error_string
 
     if (present(z)) then
       jobz = 'v'
@@ -1941,6 +1964,7 @@ contains
     integer :: n, ka, kb, ldab, ldbb, ldz, info
     character :: jobz
     complex(rdp) :: zTmp(1,1)
+    character(len=100) :: error_string
 
     if (present(z)) then
       jobz = 'v'
@@ -2039,6 +2063,7 @@ contains
 
     integer, allocatable :: iwork(:)
     integer :: lwork, liwork, n, info, iitype
+    character(len=100) :: error_string
 
     @:ASSERT(uplo == 'u' .or. uplo == 'U' .or. uplo == 'l' .or. uplo == 'L')
     @:ASSERT(jobz == 'n' .or. jobz == 'N' .or. jobz == 'v' .or. jobz == 'V')
@@ -2143,6 +2168,7 @@ contains
     integer :: n, lda, info, int_idealwork, ldvl, ldvr
     real(r${VPREC}$p) :: idealwork(1)
     character :: jobvl, jobvr
+    character(len=100) :: error_string
 
     ! If no eigenvectors requested, need a dummy array for lapack call
     real(r${VPREC}$p) :: dummyvl(1,1), dummyvr(1,1)

--- a/prog/dftb+/lib_math/lapackroutines.F90
+++ b/prog/dftb+/lib_math/lapackroutines.F90
@@ -22,10 +22,6 @@ module dftbp_lapackroutines
   private
 
 
-  !> Used to return runtime diagnostics
-  character(len=100) :: error_string
-
-
   !> Computes the solution to a real system of linear equations A * X = B, where A is an N-by-N
   !> matrix and X and B are N-by-NRHS matrices
   interface gesv
@@ -155,6 +151,8 @@ contains
     integer :: info
     integer :: nn, nrhs, lda, ldb
     integer, allocatable :: ipiv(:)
+    character(len=100) :: error_string
+
 
     lda = size(aa, dim=1)
     if (present(nEquation)) then
@@ -220,6 +218,7 @@ contains
     integer :: info
     integer :: nn, nrhs, lda, ldb
     integer, allocatable :: ipiv(:)
+    character(len=100) :: error_string
 
     lda = size(aa, dim=1)
     if (present(nEquation)) then
@@ -285,6 +284,7 @@ contains
     integer :: info
     integer :: nn, nrhs, lda, ldb
     integer, allocatable :: ipiv(:)
+    character(len=100) :: error_string
 
     lda = size(aa, dim=1)
     if (present(nEquation)) then
@@ -348,6 +348,7 @@ contains
     integer, optional, intent(out) :: iError
 
     integer :: mm, nn, lda, info
+    character(len=100) :: error_string
 
     lda = size(aa, dim=1)
     nn = size(aa, dim=2)
@@ -406,6 +407,7 @@ contains
     integer, optional, intent(out) :: iError
 
     integer :: mm, nn, lda, info
+    character(len=100) :: error_string
 
     lda = size(aa, dim=1)
     nn = size(aa, dim=2)
@@ -464,6 +466,7 @@ contains
     integer, optional, intent(out) :: iError
 
     integer :: mm, nn, lda, info
+    character(len=100) :: error_string
 
     lda = size(aa, dim=1)
     nn = size(aa, dim=2)
@@ -522,6 +525,7 @@ contains
     integer, optional, intent(out) :: iError
 
     integer :: mm, nn, lda, info
+    character(len=100) :: error_string
 
     lda = size(aa, dim=1)
     nn = size(aa, dim=2)
@@ -578,6 +582,7 @@ contains
     integer :: nn, lda, info, lwork
     real(rsp), allocatable :: work(:)
     real(rsp) :: work2(1)
+    character(len=100) :: error_string
 
     lda = size(aa, dim=1)
     if (present(nRow)) then
@@ -635,6 +640,7 @@ contains
     integer :: nn, lda, info, lwork
     real(rdp), allocatable :: work(:)
     real(rdp) :: work2(1)
+    character(len=100) :: error_string
 
     lda = size(aa, dim=1)
     if (present(nRow)) then
@@ -687,6 +693,7 @@ contains
 
     integer :: nn, info
     integer, allocatable :: ipiv(:)
+    character(len=100) :: error_string
 
     nn = size(aa, dim=1)
     if (present(nRow)) then
@@ -727,6 +734,7 @@ contains
 
     integer :: nn, info0
     integer, allocatable :: ipiv(:)
+    character(len=100) :: error_string
 
     nn = size(aa, dim=1)
     allocate(ipiv(nn))
@@ -774,6 +782,7 @@ contains
 
     integer :: nn, info0
     integer, allocatable :: ipiv(:)
+    character(len=100) :: error_string
 
     nn = size(aa, dim=1)
     allocate(ipiv(nn))
@@ -827,6 +836,7 @@ contains
     real(rsp), allocatable :: work(:)
     real(rsp) :: tmpwork(1)
     character :: uplo0
+    character(len=100) :: error_string
 
     uplo0 = uploHelper(uplo)
     nn = size(aa, dim=2)
@@ -866,6 +876,7 @@ contains
     real(rdp), allocatable :: work(:)
     real(rdp) :: tmpwork(1)
     character :: uplo0
+    character(len=100) :: error_string
 
     uplo0 = uploHelper(uplo)
     nn = size(aa, dim=2)
@@ -905,6 +916,7 @@ contains
     complex(rsp), allocatable :: work(:)
     complex(rsp) :: tmpwork(1)
     character :: uplo0
+    character(len=100) :: error_string
 
     uplo0 = uploHelper(uplo)
     nn = size(aa, dim=2)
@@ -944,6 +956,7 @@ contains
     complex(rdp), allocatable :: work(:)
     complex(rdp) :: tmpwork(1)
     character :: uplo0
+    character(len=100) :: error_string
 
     uplo0 = uploHelper(uplo)
     nn = size(aa, dim=2)
@@ -982,6 +995,7 @@ contains
     integer :: info0, nn
     character :: uplo0
     real(rsp), allocatable :: work(:)
+    character(len=100) :: error_string
 
     uplo0 = uploHelper(uplo)
     nn = size(aa, dim=1)
@@ -1015,6 +1029,7 @@ contains
     integer :: info0, nn
     character :: uplo0
     real(rdp), allocatable :: work(:)
+    character(len=100) :: error_string
 
     uplo0 = uploHelper(uplo)
     nn = size(aa, dim=1)
@@ -1048,6 +1063,7 @@ contains
     integer :: info0, nn
     character :: uplo0
     complex(rsp), allocatable :: work(:)
+    character(len=100) :: error_string
 
     uplo0 = uploHelper(uplo)
     nn = size(aa, dim=1)
@@ -1081,6 +1097,7 @@ contains
     integer :: info0, nn
     character :: uplo0
     complex(rdp), allocatable :: work(:)
+    character(len=100) :: error_string
 
     uplo0 = uploHelper(uplo)
     nn = size(aa, dim=1)
@@ -1126,6 +1143,7 @@ contains
     integer :: nn, lda, ldb, info, lwork, nrhs
     real(rsp), allocatable :: work(:)
     real(rsp) :: work2(1)
+    character(len=100) :: error_string
 
     lda = size(A, dim=1)
     if (present(nRow)) then
@@ -1204,6 +1222,7 @@ contains
     integer :: nn, lda, ldb, info, lwork, nrhs
     real(rdp), allocatable :: work(:)
     real(rdp) :: work2(1)
+    character(len=100) :: error_string
 
     lda = size(A, dim=1)
     if (present(nRow)) then
@@ -1379,6 +1398,7 @@ contains
 
     integer :: n, m, mn, lda, lwork, ldu, ldvt, info
     real(rsp), allocatable :: work(:)
+    character(len=100) :: error_string
 
     m = size(A,dim=1)
     n = size(A,dim=2)
@@ -1426,6 +1446,7 @@ contains
 
     integer :: n, m, mn, lda, lwork, ldu, ldvt, info
     real(rdp), allocatable :: work(:)
+    character(len=100) :: error_string
 
     m = size(A,dim=1)
     n = size(A,dim=2)
@@ -1473,6 +1494,7 @@ contains
     integer :: n, m, mn, lda, lwork, ldu, ldvt, info
     real(rsp), allocatable :: rwork(:)
     complex(rsp), allocatable :: work(:)
+    character(len=100) :: error_string
 
     m = size(A,dim=1)
     n = size(A,dim=2)
@@ -1523,6 +1545,7 @@ contains
     integer :: n, m, mn, lda, lwork, ldu, ldvt, info
     real(rdp), allocatable :: rwork(:)
     complex(rdp), allocatable :: work(:)
+    character(len=100) :: error_string
 
     m = size(A,dim=1)
     n = size(A,dim=2)
@@ -1569,6 +1592,7 @@ contains
 
     integer :: info0, n, ldb
     character :: uplo0
+    character(len=100) :: error_string
 
     uplo0 = uploHelper(uplo)
     n = size(b, dim=2)

--- a/prog/dftb+/lib_md/nhctherm.F90
+++ b/prog/dftb+/lib_md/nhctherm.F90
@@ -18,10 +18,6 @@ module dftbp_nhctherm
   use dftbp_message
   implicit none
 
-
-  !> Short string for error returns
-  character(lc) :: lcTmp
-
   private
 
   public :: TNHCThermostat
@@ -127,6 +123,10 @@ contains
 
     !> MD time step
     real(dp), intent(in) :: deltaT
+
+    !> Short string for error returns
+    character(lc) :: lcTmp
+
     integer, intent(in) :: npart
     integer, intent(in) :: nys
     integer, intent(in) :: nc

--- a/prog/dftb+/lib_timedep/dynamics.F90
+++ b/prog/dftb+/lib_timedep/dynamics.F90
@@ -293,9 +293,6 @@ module dftbp_timeprop
   !> Prefix for dump files for restart
   character(*), parameter :: restartFileName = 'tddump'
 
-  !> Used to return runtime diagnostics
-  character(len=120) :: error_string
-
 contains
 
   !> Initialisation of input variables
@@ -2505,6 +2502,8 @@ contains
     logical, intent(in) :: tAsciiFile
 
     integer :: fd, ii, jj, kk, iErr
+    character(len=120) :: error_string
+
 
     if (tAsciiFile) then
       open(newunit=fd, file=trim(fileName) // '.dat', position="rewind", status="replace",&
@@ -2594,6 +2593,7 @@ contains
     integer :: fd, ii, jj, kk, nOrb, nSpin, nAtom, version, iErr
     real(dp) :: deltaT
     logical :: tExist
+    character(len=120) :: error_string
 
     if (tAsciiFile) then
       inquire(file=trim(fileName)//'.dat', exist=tExist)

--- a/prog/dftb+/lib_timedep/linrespgrad.F90
+++ b/prog/dftb+/lib_timedep/linrespgrad.F90
@@ -34,8 +34,6 @@ module dftbp_linrespgrad
 
   public :: LinRespGrad_old
 
-  character(lc) :: tmpStr
-
   !> Output files for results
   character(*), parameter :: transitionsOut = "TRA.DAT"
   character(*), parameter :: XplusYOut = "XplusY.DAT"
@@ -180,6 +178,7 @@ contains
     integer :: i, j, iSpin, isym, iLev, nStartLev, nEndLev
     integer :: nSpin
     character :: sym
+    character(lc) :: tmpStr
 
     real(dp) :: energyThreshold
 
@@ -714,6 +713,7 @@ contains
 
     integer :: iState
     real(dp), allocatable :: Hv(:), orthnorm(:,:)
+    character(lc) :: tmpStr
 
     nexc = size(eval)
     natom = size(gammaMat, dim=1)

--- a/prog/dftb+/lib_timedep/rs_linresp.F90
+++ b/prog/dftb+/lib_timedep/rs_linresp.F90
@@ -66,8 +66,6 @@ module dftbp_rs_linearresponse
   !> Maximal allowed iteration in the ARPACK solver.
   integer, parameter :: MAX_AR_ITER = 300
 
-  character(lc) :: tmpStr
-
   !> Communication with ARPACK for progress information
   integer :: ndigit
   integer :: msaupd, msaup2, msaitr, mseigt, msapps, msgets, mseupd
@@ -827,6 +825,7 @@ contains
 
     !> aux variables
     integer :: mu, nu
+    character(lc) :: tmpStr
 
     ! For now, spin-polarized calculation not supported
     tSpin = .false.


### PR DESCRIPTION
Make global variables local wherever possible (return codes etc.);
change global variables to parameters wherever possible;
put lineFormat in dftb_hsdparser into subroutine parseHSD_opened() and propagate into subroutine parse_recursive()